### PR TITLE
Allow version 5.4 or 6.0 of the "symfony/filesystem" package // VNLA-8314

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
     "require": {
         "php": ">=8.0",
         "vanilla/garden-http": "^3.0",
-        "symfony/filesystem": ">=5.4",
+        "symfony/filesystem": "^5.4 || ^6.0",
         "symfony/process": "*",
         "vanilla/garden-schema": ">=3.0"
     },


### PR DESCRIPTION
Making the Vanilla platform compatible to PHP 8.3 requires us to bump this package's "symfony/filesystem" dependency to version 6.0. For compatibility's sake we'll allow either 5.4 or 6.0.